### PR TITLE
Improves setUp by using the test_config parameter

### DIFF
--- a/backend/flaskr/__init__.py
+++ b/backend/flaskr/__init__.py
@@ -11,7 +11,12 @@ QUESTIONS_PER_PAGE = 10
 def create_app(test_config=None):
     # create and configure the app
     app = Flask(__name__)
-    setup_db(app)
+
+    if test_config is None:
+        setup_db(app)
+    else:
+        database_path = test_config.get('SQLALCHEMY_DATABASE_URI')
+        setup_db(app, database_path=database_path)
 
     """
     @TODO: Set up CORS. Allow '*' for origins. Delete the sample route after completing the TODOs

--- a/backend/test_flaskr.py
+++ b/backend/test_flaskr.py
@@ -12,18 +12,15 @@ class TriviaTestCase(unittest.TestCase):
 
     def setUp(self):
         """Define test variables and initialize app."""
-        self.app = create_app()
-        self.client = self.app.test_client
         self.database_name = "trivia_test"
         self.database_path = "postgres://{}/{}".format('localhost:5432', self.database_name)
-        setup_db(self.app, self.database_path)
+        
+        self.app = create_app({
+            "SQLALCHEMY_DATABASE_URI": self.database_path
+        })
 
-        # binds the app to the current context
-        with self.app.app_context():
-            self.db = SQLAlchemy()
-            self.db.init_app(self.app)
-            # create all tables
-            self.db.create_all()
+        self.client = self.app.test_client
+
     
     def tearDown(self):
         """Executed after reach test"""


### PR DESCRIPTION
This improvement avoids create two database instances in Flask which is not allowed on newer version.
By leveraging on already existing code, I propose the following in this commit.

* Passes the `self.database_path` to `create_app`
* `setup_db` takes the `database_path` as argument from the `test_config`
* `setup_db` is only called once and is compatible with newer versions of Flask if the project dependencies are updated